### PR TITLE
Type symbols are getting created with symbol type EqualSign

### DIFF
--- a/src/Symbols.ts
+++ b/src/Symbols.ts
@@ -202,7 +202,7 @@ export class TabSymbol extends Symbol {
 
 export class Type extends Symbol {
     public constructor(lineNumber : number, parent : ISymbol, position : number, text : string) {
-        super(lineNumber, parent, position, SymbolType.EqualSign, text);        
+        super(lineNumber, parent, position, SymbolType.Type, text);        
     }
 
     public static createFromValue(value : ValueSymbol) : Type {


### PR DESCRIPTION
This fixes #7. The Type class was constructing a new Symbol with
a type of EqualSign instead of Type
